### PR TITLE
Feature/#3 input

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
   "rules": {
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/jsx-props-no-spreading": "OFF",
-    "react/function-component-definition": "OFF"
+    "react/function-component-definition": "OFF",
+    "react/require-default-props": "OFF"
   }
 }

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -1,0 +1,82 @@
+import styled from "@emotion/styled";
+import PropTypes from "prop-types";
+
+const Wrapper = styled.div`
+  display: ${({ block }) => (block ? "block" : "inline-block")};
+  width: ${({ width }) => (width ? `${width}px` : "670px")};
+  height: ${({ height }) => (height ? `${height}px` : "68px")};
+`;
+
+const Label = styled.label`
+  display: block;
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 32px;
+`;
+
+const StyledInput = styled.input`
+  width: 100%;
+  height: 100%;
+  padding: 4px 8px 4px 40px;
+  border: 1px solid ${({ invalid }) => (invalid ? "red" : "gray")};
+  border-radius: 15px;
+  box-sizing: border-box;
+  background-color: #d9d9d9;
+  font-size: 30px;
+  font-weight: 700;
+  line-height: 32px;
+  letter-spacing: -0.017em;
+  &::placeholder {
+    display: flex;
+    align-items: center;
+    color: rgba(0, 0, 0, 0.42);
+  }
+`;
+
+const Input = ({
+  label,
+  type = "text",
+  block = false,
+  invalid = true,
+  required = false,
+  disabled = false,
+  readonly = false,
+  placeholder = "",
+  maxLength,
+  wrapperProps = {},
+  labelStyles = {},
+  inputStyles = {},
+  ...props
+}) => (
+  <Wrapper block={block} {...wrapperProps}>
+    <Label style={labelStyles}>{label}</Label>
+    <StyledInput
+      type={type}
+      invalid={invalid}
+      required={required}
+      disabled={disabled}
+      readOnly={readonly}
+      maxLength={maxLength}
+      placeholder={placeholder}
+      style={inputStyles}
+      {...props}
+    />
+  </Wrapper>
+);
+
+Input.propTypes = {
+  label: PropTypes.string,
+  type: PropTypes.oneOf(["text", "checkbox", "email", "password", "submit"]),
+  block: PropTypes.bool,
+  invalid: PropTypes.bool,
+  required: PropTypes.bool,
+  disabled: PropTypes.bool,
+  readonly: PropTypes.bool,
+  placeholder: PropTypes.string,
+  maxLength: PropTypes.number,
+  labelStyles: PropTypes.shape(),
+  inputStyles: PropTypes.shape(),
+  wrapperProps: PropTypes.shape(),
+};
+
+export default Input;

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -3,8 +3,8 @@ import PropTypes from "prop-types";
 
 const Wrapper = styled.div`
   display: ${({ block }) => (block ? "block" : "inline-block")};
-  width: ${({ width }) => (width ? `${width}px` : "670px")};
-  height: ${({ height }) => (height ? `${height}px` : "68px")};
+  width: 670px;
+  height: 68ox;
 `;
 
 const Label = styled.label`
@@ -44,11 +44,12 @@ const Input = ({
   placeholder = "",
   maxLength,
   wrapperProps = {},
+  wrapperStyles = {},
   labelStyles = {},
   inputStyles = {},
   ...props
 }) => (
-  <Wrapper block={block} {...wrapperProps}>
+  <Wrapper block={block} {...wrapperProps} style={wrapperStyles}>
     <Label style={labelStyles}>{label}</Label>
     <StyledInput
       type={type}
@@ -76,6 +77,7 @@ Input.propTypes = {
   maxLength: PropTypes.number,
   labelStyles: PropTypes.shape(),
   inputStyles: PropTypes.shape(),
+  wrapperStyles: PropTypes.shape(),
   wrapperProps: PropTypes.shape(),
 };
 

--- a/src/stories/components/Input.stories.js
+++ b/src/stories/components/Input.stories.js
@@ -44,6 +44,9 @@ export default {
     wrapperProps: {
       defaultValue: {},
     },
+    wrapperStyles: {
+      defaultValue: {},
+    },
     labelStyles: {
       defaultValue: {},
     },

--- a/src/stories/components/Input.stories.js
+++ b/src/stories/components/Input.stories.js
@@ -1,0 +1,56 @@
+import Input from "../../components/Input/Input";
+
+export default {
+  title: "Component/Input",
+  component: Input,
+  argTypes: {
+    label: {
+      defaultValue: "",
+      control: "text",
+    },
+    type: {
+      defaultValue: "text",
+      options: ["text", "checkbox", "email", "password", "submit"],
+      control: { type: "radio" },
+    },
+    block: {
+      defaultValue: false,
+      control: "boolean",
+    },
+    invalid: {
+      defaultValue: false,
+      control: "boolean",
+    },
+    required: {
+      defaultValue: false,
+      control: "boolean",
+    },
+    disabled: {
+      defaultValue: false,
+      control: "boolean",
+    },
+    readonly: {
+      defaultValue: false,
+      control: "boolean",
+    },
+    maxLength: {
+      defaultValue: 7,
+      control: "number",
+    },
+    placeholder: {
+      defaultValue: "Email",
+      control: "text",
+    },
+    wrapperProps: {
+      defaultValue: {},
+    },
+    labelStyles: {
+      defaultValue: {},
+    },
+    inputStyles: {
+      defaultValue: {},
+    },
+  },
+};
+
+export const Default = args => <Input {...args} />;


### PR DESCRIPTION
# 개요

Input 컴포넌트 만들기

# 작업 내용

- Input 컴포넌트 작성
- Input story 작성
- figma 기준으로 기본 스타일 구현.
- `wrapperStyles`, `inputStyles`, `labelStyles` prop으로 커스터마이징해서 사용 가능.

# 사진
<img width="1440" alt="스크린샷 2022-06-10 오후 11 56 26" src="https://user-images.githubusercontent.com/16220817/173093230-b50cbf8e-1819-48a8-a983-32b552c914a9.png">

# 중점적으로 봐줬으면 하는 부분 (선택 사항)
개인적으로 삽질한 부분 공유합니다.
- maxlength가 적용이 안되서 오래 걸렸는데 maxLength로 적용하니 작동했습니다 😭 

## 기존 PR을 main에 잘못 merge하여 원복 후 다시 올립니다. (죄송합니다 ㅠ)

## 원복한 방법
(main 브랜치에서)
- git reset --merge ORIG_HEAD
- git push -f origin main

close #3 