### PR TITLE
Feature/#12 ImageUpload 컴포넌트 구현

### DIFF
--- a/src/components/ImageUpload/ImageUpload.js
+++ b/src/components/ImageUpload/ImageUpload.js
@@ -1,0 +1,75 @@
+import styled from "@emotion/styled";
+import { useRef, useState } from "react";
+import PropTypes from "prop-types";
+import PreviewImage from "./PreviewImage";
+import Image from "../Image/Image";
+
+const UploadContainer = styled.div`
+  display: inline-flex;
+  cursor: pointer;
+`;
+
+const Input = styled.input`
+  display: none;
+`;
+
+const ImageUpload = ({
+  isInnerPreview = false,
+  children,
+  previewImageWrapperStyles,
+  previewImageStyles,
+  name,
+  ...props
+}) => {
+  const [previewItem, setPreviewItem] = useState(null);
+  const inputRef = useRef(null);
+
+  const handleFileChange = e => {
+    const {
+      target: { files },
+    } = e;
+
+    if (files.length === 0) {
+      return;
+    }
+
+    const [changedFile] = files;
+
+    const src = URL.createObjectURL(changedFile);
+    const image = <Image alt="사진 미리보기" src={src} {...previewImageStyles} />;
+
+    setPreviewItem(image);
+  };
+
+  const handleChooseFile = () => {
+    inputRef.current.click();
+  };
+
+  return (
+    <>
+      <UploadContainer onClick={handleChooseFile} {...props}>
+        <Input ref={inputRef} type="file" name={name} accept="image/*" onChange={handleFileChange} />
+        {isInnerPreview ? (
+          <PreviewImage previewImageWrapperStyles={previewImageWrapperStyles} previewItem={previewItem}>
+            {children}
+          </PreviewImage>
+        ) : (
+          children
+        )}
+      </UploadContainer>
+      {!isInnerPreview && (
+        <PreviewImage previewImageWrapperStyles={previewImageWrapperStyles} previewItem={previewItem} />
+      )}
+    </>
+  );
+};
+
+ImageUpload.propTypes = {
+  isInnerPreview: PropTypes.bool,
+  children: PropTypes.node,
+  previewImageWrapperStyles: PropTypes.shape(),
+  previewImageStyles: PropTypes.shape(),
+  name: PropTypes.string,
+};
+
+export default ImageUpload;

--- a/src/components/ImageUpload/PreviewImage.js
+++ b/src/components/ImageUpload/PreviewImage.js
@@ -1,0 +1,30 @@
+import styled from "@emotion/styled";
+import PropTypes from "prop-types";
+import React from "react";
+
+const PreviewImage = ({ children, previewImageWrapperStyles, previewItem }) => {
+  const PreviewImageWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 40px;
+    padding-left: 40px;
+    background-color: #d9d9d9;
+    width: 1130px;
+    height: 245px;
+    border-radius: 15px;
+  `;
+
+  return children ? (
+    React.cloneElement(children, null, [previewItem])
+  ) : (
+    <PreviewImageWrapper style={previewImageWrapperStyles}>{previewItem}</PreviewImageWrapper>
+  );
+};
+
+PreviewImage.propTypes = {
+  children: PropTypes.node,
+  previewImageWrapperStyles: PropTypes.shape(),
+  previewItem: PropTypes.node,
+};
+
+export default PreviewImage;

--- a/src/stories/components/ImageUpload.stories.js
+++ b/src/stories/components/ImageUpload.stories.js
@@ -27,7 +27,7 @@ const Label = styled.label`
 `;
 
 export const ImageFile = args => (
-  <ImageUpload previewImageStyles={{ width: "160px", height: "200px" }} {...args}>
+  <ImageUpload {...args} previewImageStyles={{ width: "160px", height: "200px" }}>
     <Label>사진</Label>
     <button type="button">+</button>
   </ImageUpload>
@@ -42,7 +42,7 @@ const ProfileImage = styled.div`
 `;
 
 export const Profile = args => (
-  <ImageUpload isInnerPreview previewImageStyles={{ width: "100%", height: "100%", mode: "cover" }} {...args}>
+  <ImageUpload {...args} isInnerPreview previewImageStyles={{ width: "100%", height: "100%", mode: "cover" }}>
     <ProfileImage />
   </ImageUpload>
 );

--- a/src/stories/components/ImageUpload.stories.js
+++ b/src/stories/components/ImageUpload.stories.js
@@ -1,0 +1,48 @@
+import styled from "@emotion/styled";
+import ImageUpload from "../../components/ImageUpload/ImageUpload";
+
+export default {
+  title: "Component/ImageUpload",
+  component: ImageUpload,
+  argTypes: {
+    previewImageWrapperStyles: {
+      defaultValue: {},
+    },
+    previewImageStyles: {
+      defaultValue: {},
+    },
+  },
+};
+
+export const Default = () => (
+  <ImageUpload>
+    <button type="button">click me</button>
+  </ImageUpload>
+);
+const Label = styled.label`
+  display: block;
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 32px;
+`;
+
+export const ImageFile = args => (
+  <ImageUpload previewImageStyles={{ width: "160px", height: "200px" }} {...args}>
+    <Label>사진</Label>
+    <button type="button">+</button>
+  </ImageUpload>
+);
+
+const ProfileImage = styled.div`
+  width: 400px;
+  height: 400px;
+  border-radius: 50%;
+  background-color: #d9d9d9;
+  overflow: hidden;
+`;
+
+export const Profile = args => (
+  <ImageUpload isInnerPreview previewImageStyles={{ width: "100%", height: "100%", mode: "cover" }} {...args}>
+    <ProfileImage />
+  </ImageUpload>
+);


### PR DESCRIPTION
# 개요

ImageUpload 컴포넌트 구현

# 작업 내용

- 클릭시 이미지 파일을 업로드.
- `UploadContainer`와 `PreviewImage` 분리.
- `isInnerPreview` prop으로 미리보기 그림을 UploadContainer 안에 둘지 밖에 둘지 결정.
- 드래그 앤 드랍 미구현
- multiple 업로드는 나중에 구현할 예정

# 사진
<img width="1440" alt="스크린샷 2022-06-13 오후 5 49 48" src="https://user-images.githubusercontent.com/16220817/173316332-932fb0a8-3809-4255-8874-50c120ec0582.png">
<img width="1440" alt="스크린샷 2022-06-13 오후 5 50 02" src="https://user-images.githubusercontent.com/16220817/173316348-165c509c-5322-4541-815f-9dcba8ed5caa.png">



# 중점적으로 봐줬으면 하는 부분 (선택 사항)
