### PR TITLE
Fix/#32 input

### DIFF
--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -3,8 +3,8 @@ import PropTypes from "prop-types";
 
 const Wrapper = styled.div`
   display: ${({ block }) => (block ? "block" : "inline-block")};
-  width: 670px;
-  height: 68px;
+  width: 100%;
+  height: 100%;
 `;
 
 const Label = styled.label`

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -37,7 +37,7 @@ const Input = ({
   label,
   type = "text",
   block = false,
-  invalid = true,
+  invalid = false,
   required = false,
   disabled = false,
   readonly = false,

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -75,10 +75,10 @@ Input.propTypes = {
   readonly: PropTypes.bool,
   placeholder: PropTypes.string,
   maxLength: PropTypes.number,
-  labelStyles: PropTypes.shape(),
-  inputStyles: PropTypes.shape(),
-  wrapperStyles: PropTypes.shape(),
-  wrapperProps: PropTypes.shape(),
+  labelStyles: PropTypes.objectOf(PropTypes.string),
+  inputStyles: PropTypes.objectOf(PropTypes.string),
+  wrapperStyles: PropTypes.objectOf(PropTypes.string),
+  wrapperProps: PropTypes.objectOf(PropTypes.string),
 };
 
 export default Input;

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 const Wrapper = styled.div`
   display: ${({ block }) => (block ? "block" : "inline-block")};
   width: 670px;
-  height: 68ox;
+  height: 68px;
 `;
 
 const Label = styled.label`

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -17,7 +17,7 @@ const Label = styled.label`
 const StyledInput = styled.input`
   width: 100%;
   height: 100%;
-  padding: 4px 8px 4px 40px;
+  padding: ${({ label }) => (label ? `4px 8px 4px 40px` : `4px 8px 4px 4px`)};
   border: 1px solid ${({ invalid }) => (invalid ? "red" : "gray")};
   border-radius: 15px;
   box-sizing: border-box;


### PR DESCRIPTION
# 개요

Input 컴포넌트 오타 수정 및 리팩토링

# 작업 내용

- height 오타 수정.
- Wrapper 기본 width 100%.
- nvalid default false로 수정.
- label 유무에 따른 기본 padding 값 변경.
- PropTypes shape 에서 objectOf로 수정.

# 사진
<img width="1440" alt="스크린샷 2022-06-15 오전 11 25 50" src="https://user-images.githubusercontent.com/16220817/173723456-de8f149f-45ff-414a-92d4-249b77d7b953.png">


# 중점적으로 봐줬으면 하는 부분 (선택 사항)
