### PR TITLE
Feature/#27 글 작성 페이지 레이아웃 구현

### DIFF
--- a/src/components/ImageUpload/ImageUpload.js
+++ b/src/components/ImageUpload/ImageUpload.js
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import PreviewImage from "./PreviewImage";
 import Image from "../Image/Image";
@@ -13,6 +13,8 @@ const Input = styled.input`
   display: none;
 `;
 
+const reader = new FileReader();
+
 const ImageUpload = ({
   isInnerPreview = false,
   children,
@@ -22,7 +24,21 @@ const ImageUpload = ({
   ...props
 }) => {
   const [previewItem, setPreviewItem] = useState(null);
+  const [binaryImage, setBinaryImage] = useState(null);
   const inputRef = useRef(null);
+
+  const handleLoad = () => {
+    setBinaryImage(reader.result);
+    const image = <Image alt="사진 미리보기" src={reader.result} {...previewImageStyles} />;
+
+    setPreviewItem(image);
+  };
+
+  useEffect(() => {
+    reader.addEventListener("load", handleLoad);
+
+    return () => reader.removeEventListener("loader", handleLoad);
+  }, []);
 
   const handleFileChange = e => {
     const {
@@ -35,10 +51,7 @@ const ImageUpload = ({
 
     const [changedFile] = files;
 
-    const src = URL.createObjectURL(changedFile);
-    const image = <Image alt="사진 미리보기" src={src} {...previewImageStyles} />;
-
-    setPreviewItem(image);
+    reader.readAsDataURL(changedFile);
   };
 
   const handleChooseFile = () => {
@@ -48,7 +61,14 @@ const ImageUpload = ({
   return (
     <>
       <UploadContainer onClick={handleChooseFile} {...props}>
-        <Input ref={inputRef} type="file" name={name} accept="image/*" onChange={handleFileChange} />
+        <Input
+          ref={inputRef}
+          type="file"
+          name={name}
+          accept="image/*"
+          onChange={handleFileChange}
+          data-binary-image={binaryImage}
+        />
         {isInnerPreview ? (
           <PreviewImage previewImageWrapperStyles={previewImageWrapperStyles} previewItem={previewItem}>
             {children}

--- a/src/components/ImageUpload/PreviewImage.js
+++ b/src/components/ImageUpload/PreviewImage.js
@@ -9,9 +9,10 @@ const PreviewImage = ({ children, previewImageWrapperStyles, previewItem }) => {
     gap: 40px;
     padding-left: 40px;
     background-color: #d9d9d9;
-    width: 1130px;
+    width: 100%;
     height: 245px;
     border-radius: 15px;
+    box-sizing: border-box;
   `;
 
   return children ? (

--- a/src/pages/Post/WritingPostPage.js
+++ b/src/pages/Post/WritingPostPage.js
@@ -1,0 +1,97 @@
+import styled from "@emotion/styled";
+import Button from "../../components/Button/Button";
+import UpperHeader from "../../components/Header/UpperHeader";
+import ImageUpload from "../../components/ImageUpload/ImageUpload";
+import Input from "../../components/Input/Input";
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin: 32px 15%;
+`;
+
+const Label = styled.label`
+  display: block;
+  flex-shrink: 0;
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 32px;
+  cursor: pointer;
+`;
+
+const AddWrapper = styled.label`
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 24px;
+`;
+
+const StyledTextArea = styled.textarea`
+  width: 100%;
+  height: 240px;
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 32px;
+  background-color: #d9d9d9;
+  border-radius: 15px;
+  border: 1px solid;
+  resize: none;
+  box-sizing: border-box;
+`;
+
+const SubmitWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 24px;
+  width: 100%;
+`;
+
+const handleSubmit = e => {
+  e.preventDefault();
+
+  const { binaryImage } = e.target.imageUpload.dataset;
+  console.log(binaryImage);
+
+  // TODO: api.post
+  alert(`글 작성 등록\n제목: ${e.target.titleInput.value}, 내용: ${e.target.content.value}\n ${binaryImage}`);
+};
+
+// TODO: 취소시 뒤로가기
+const handleCancleClick = () => {
+  // 뒤로가기 구현
+  alert("글 작성 취소");
+};
+
+const WritingPostPage = () => (
+  <>
+    <UpperHeader />
+    <Form onSubmit={handleSubmit}>
+      <Input
+        label="제목"
+        name="titleInput"
+        wrapperStyles={{ display: "flex", "flex-direction": "column", gap: "24px" }}
+        required
+      />
+      <ImageUpload name="imageUpload" previewImageStyles={{ width: "160px", height: "200px" }} required>
+        <AddWrapper>
+          <Label>사진</Label>
+          <Button height="32px" backgroundColor="transparent" color="black">
+            +
+          </Button>
+        </AddWrapper>
+      </ImageUpload>
+      <Label>피드백 받고 싶은 내용을 적어주세요.</Label>
+      <StyledTextArea name="content" required />
+      <SubmitWrapper>
+        <Button onClick={handleCancleClick} width="25%">
+          취소
+        </Button>
+        <Button type="submit" width="25%">
+          작성 완료
+        </Button>
+      </SubmitWrapper>
+    </Form>
+  </>
+);
+
+export default WritingPostPage;

--- a/src/stories/pages/PostPage/WritingPostPage.stories.js
+++ b/src/stories/pages/PostPage/WritingPostPage.stories.js
@@ -1,0 +1,8 @@
+import WritingPostPage from "../../../pages/Post/WritingPostPage";
+
+export default {
+  title: "Page/WitePostingPage",
+  component: WritingPostPage,
+};
+
+export const Default = args => <WritingPostPage {...args} />;


### PR DESCRIPTION
# 개요

글 작성 페이지 컴포넌트 구현 중 레이아웃만 구현

# 작업 내용

- 레이아웃 구현
- 기능 구현, 페이지 이동, API 연동 추가 구현 필요

# 사진

<img width="1440" alt="스크린샷 2022-06-15 오후 4 36 32" src="https://user-images.githubusercontent.com/16220817/173770276-9eaa0078-9eec-4f79-814b-589240a81680.png">
<img width="1440" alt="스크린샷 2022-06-15 오후 4 36 50" src="https://user-images.githubusercontent.com/16220817/173770330-9ecc50d2-4c1b-4438-a6f7-247b4d1b6dbc.png">


# 중점적으로 봐줬으면 하는 부분 (선택 사항)
