### PR TITLE
Fix/#57-button 버그 수정

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -30,9 +30,9 @@ const StyledButton = styled.button`
     "&:active": active,
     ...style,
   })}
-  border: ${(borderWidth, borderColor) =>
+  border: ${({ borderWidth, borderColor }) =>
     borderWidth ? `${borderWidth} solid ${borderColor}` : "none"};
-  border-radius: ${borderRadius => borderRadius || "15px"};
+  border-radius: ${({ borderRadius }) => borderRadius || "15px"};
 `;
 
 const Button = ({

--- a/src/stories/components/Button.stories.js
+++ b/src/stories/components/Button.stories.js
@@ -1,3 +1,4 @@
+import { Heart } from "react-feather";
 import Button from "../../components/Button/Button";
 import Common from "../../styles/common";
 
@@ -41,3 +42,9 @@ export default {
 };
 
 export const Default = args => <Button {...args}>버튼</Button>;
+
+export const IconButton = args => (
+  <Button {...args}>
+    <Heart />
+  </Button>
+);


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description -->

# 개요
- Button 컴포넌트 children에 component 등의 element 들어가면 에러 나는 버그 수정

# 작업 내용
- `styled.button` 내부의 비구조화 할당이 잘못되어 코드 수정했습니다.

# 사진
<img width="634" alt="image" src="https://user-images.githubusercontent.com/24430239/174244840-27f5e1a6-b9e8-4703-9d56-00a7c35f09f2.png">


# 중점적으로 봐줬으면 하는 부분 (선택 사항)
