### PR TITLE
Feature/#27-글 작성 페이지 API 연동

### DIFF
--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -1,0 +1,86 @@
+/* eslint-disable react/prop-types */
+import styled from "@emotion/styled";
+import PropTypes from "prop-types";
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`;
+
+const Label = styled.label`
+  display: block;
+  flex-shrink: 0;
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 32px;
+`;
+
+const StyledSelect = styled.select`
+  width: 100%;
+  padding: 4px 8px;
+  border: 1px solid ${({ invalid }) => (invalid ? "red" : "gray")};
+  border-radius: 4px;
+  box-sizing: border-box;
+`;
+
+const Select = ({
+  data,
+  label,
+  placeholder,
+  name,
+  invalid = false,
+  required = false,
+  disabled = false,
+  wrapperProps,
+  ...props
+}) => {
+  const formattedData = data.map(item =>
+    typeof item === "string" ? { label: item, value: item } : item,
+  );
+
+  const options = formattedData.map(item => (
+    <option key={item.value} value={item.value}>
+      {item.label}
+    </option>
+  ));
+
+  if (placeholder) {
+    options.unshift(
+      <option key="placeholder" value="" hidden>
+        {placeholder}
+      </option>,
+    );
+  }
+
+  return (
+    <Wrapper {...wrapperProps}>
+      <Label>{label}</Label>
+      <StyledSelect
+        invalid={invalid}
+        required={required}
+        disabled={disabled}
+        name={name}
+        {...props}
+      >
+        {options}
+      </StyledSelect>
+    </Wrapper>
+  );
+};
+
+Select.propTypes = {
+  data: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.object),
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
+  label: PropTypes.string,
+  placeholder: PropTypes.string,
+  name: PropTypes.string,
+  invalid: PropTypes.bool,
+  required: PropTypes.bool,
+  disabled: PropTypes.bool,
+  wrapperProps: PropTypes.objectOf(PropTypes.string),
+};
+
+export default Select;

--- a/src/pages/Post/WritingPostPage.js
+++ b/src/pages/Post/WritingPostPage.js
@@ -9,6 +9,7 @@ import useForm from "../../hooks/useForm";
 import { useGlobalContext } from "../../store/GlobalProvider";
 import Select from "../../components/Select/Select";
 import { createPost } from "../../utils/apis/posts";
+import Footer from "../../components/Footer/Footer";
 
 const Form = styled.form`
   display: flex;
@@ -166,6 +167,7 @@ const WritingPostPage = () => {
           </Button>
         </SubmitWrapper>
       </Form>
+      <Footer />
       <Modal
         width="50%"
         visible={modalVisible}

--- a/src/pages/Post/WritingPostPage.js
+++ b/src/pages/Post/WritingPostPage.js
@@ -40,7 +40,7 @@ const StyledTextArea = styled.textarea`
   line-height: 32px;
   background-color: #d9d9d9;
   border-radius: 15px;
-  border: 1px solid;
+  border: none;
   resize: none;
   box-sizing: border-box;
 `;
@@ -124,6 +124,11 @@ const WritingPostPage = () => {
           }
           placeholder="카테고리를 선택해주세요"
           onChange={handleChange}
+          style={{
+            backgroundColor: "#d9d9d9",
+            border: "none",
+            borderRadius: "15px",
+          }}
         />
         <Input
           label="제목"
@@ -131,6 +136,9 @@ const WritingPostPage = () => {
             display: "flex",
             "flex-direction": "column",
             gap: "24px",
+          }}
+          inputStyles={{
+            border: "none",
           }}
           name="title"
           onChange={handleChange}

--- a/src/stories/components/Select.stories.js
+++ b/src/stories/components/Select.stories.js
@@ -1,0 +1,39 @@
+import Select from "../../components/Select/Select";
+
+export default {
+  title: "Component/Select",
+  component: Select,
+  argTypes: {
+    label: {
+      defaultValue: "Label",
+      control: "text",
+    },
+    placeholder: {
+      defaultValue: "Placeholder",
+      control: "text",
+    },
+    invalid: {
+      defaultValue: false,
+      control: "boolean",
+    },
+    disabled: {
+      defaultValue: false,
+      control: "boolean",
+    },
+    required: {
+      defaultValue: false,
+      control: "boolean",
+    },
+  },
+};
+
+export const Default = args => (
+  <Select
+    data={[
+      { label: "채널1", value: "id1" },
+      { label: "채널2", value: "id2" },
+      { label: "채널3", value: "id3" },
+    ]}
+    {...args}
+  />
+);

--- a/src/stories/pages/PostPage/WritingPostPage.stories.js
+++ b/src/stories/pages/PostPage/WritingPostPage.stories.js
@@ -1,8 +1,20 @@
+import { useEffect } from "react";
 import WritingPostPage from "../../../pages/Post/WritingPostPage";
+import { useGetChannelList } from "../../../utils/apis/channels";
+import { useGlobalContext } from "../../../store/GlobalProvider";
 
 export default {
   title: "Page/WitePostingPage",
   component: WritingPostPage,
 };
 
-export const Default = args => <WritingPostPage {...args} />;
+export const Default = args => {
+  const { setChannels } = useGlobalContext();
+  const { data: channels } = useGetChannelList();
+
+  useEffect(() => {
+    setChannels(channels);
+  }, [channels]);
+
+  return <WritingPostPage {...args} />;
+};


### PR DESCRIPTION
# 개요

글 작성 페이지 API 연동

# 작업 내용

- 글 작성 페이지에서 제출 버튼 클릭시 api를 통해 post 등록.
- input, textarea border 삭제

## TODO

- [ ] content 칼럼도 post 등록해야함.
- [ ] 전역상태의 token 값을 사용.
- [ ] 라우팅 연결

# 사진


# 중점적으로 봐줬으면 하는 부분 (선택 사항)
