### PR TITLE
Feature/#76 글 작성 페이지 라우팅 적용

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,6 +5,7 @@ import axios from "axios";
 import resetStyle from "../src/styles/reset";
 import globalStyle from "../src/styles/style";
 import GlobalProvider from "../src/store/GlobalProvider";
+import { MemoryRouter } from "react-router";
 
 const queryClient = new QueryClient();
 
@@ -12,7 +13,7 @@ axios.defaults.baseURL = `http://kdt.frontend.2nd.programmers.co.kr:5006`;
 
 export const decorators = [
   Story => (
-    <>
+    <MemoryRouter initialEntries={["/"]}>
       <QueryClientProvider client={queryClient}>
         <ReactQueryDevtools initialIsOpen={false} />
         <Global styles={[resetStyle, globalStyle]} />
@@ -20,7 +21,7 @@ export const decorators = [
           <Story />
         </GlobalProvider>
       </QueryClientProvider>
-    </>
+    </MemoryRouter>
   ),
 ];
 

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import Login from "./pages/Login/Login";
 import SignUp from "./pages/SignUp/SignUp";
 import { useGetChannelList } from "./utils/apis/channels";
 import { useGlobalContext } from "./store/GlobalProvider";
+import WritingPostPage from "./pages/Post/WritingPostPage";
 
 axios.defaults.baseURL = `http://kdt.frontend.2nd.programmers.co.kr:5006`;
 
@@ -28,6 +29,7 @@ function App() {
           <Route path="/" element={<MainPage />} />
           <Route path="login" element={<Login />} />
           <Route path="signup" element={<SignUp />} />
+          <Route path="write" element={<WritingPostPage />} />
           {/* <Route path="*" element={<NotFound />}></Route> */}
         </Routes>
       </BrowserRouter>

--- a/src/pages/Post/WritingPostPage.js
+++ b/src/pages/Post/WritingPostPage.js
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import Modal from "../../components/Modal/Modal";
 import Button from "../../components/Button/Button";
 import UpperHeader from "../../components/Header/UpperHeader";
@@ -53,14 +54,10 @@ const SubmitWrapper = styled.div`
   width: 100%;
 `;
 
-// TODO: 취소시 뒤로가기
-const handleCancleClick = () => {
-  // 뒤로가기 구현
-  alert("글 작성 취소");
-};
-
 const WritingPostPage = () => {
   const { state } = useGlobalContext();
+  const navigate = useNavigate();
+  const goMainPage = ({ replace = false }) => navigate("/", { replace });
 
   const { errors, handleChange, handleSubmit } = useForm({
     initialValues: {
@@ -79,6 +76,7 @@ const WritingPostPage = () => {
       // TODO: 전역상태의 token 사용하기
       // createPost({ title, image, channelId, token: state.userInfo.token });
       createPost({ title, image, channelId, token });
+      goMainPage({ replace: true });
     },
     validate: ({ title, image, content, channelId }) => {
       const error = {};
@@ -159,7 +157,7 @@ const WritingPostPage = () => {
         <Label>피드백 받고 싶은 내용을 적어주세요.</Label>
         <StyledTextArea name="content" onChange={handleChange} />
         <SubmitWrapper>
-          <Button onClick={handleCancleClick} width="25%">
+          <Button width="25%" onClick={goMainPage}>
             취소
           </Button>
           <Button type="submit" width="25%">

--- a/src/pages/Post/WritingPostPage.js
+++ b/src/pages/Post/WritingPostPage.js
@@ -75,8 +75,13 @@ const WritingPostPage = () => {
 
       // TODO: 전역상태의 token 사용하기
       // createPost({ title, image, channelId, token: state.userInfo.token });
-      createPost({ title, image, channelId, token });
-      goMainPage({ replace: true });
+
+      try {
+        createPost({ title, image, channelId, token });
+        goMainPage({ replace: true });
+      } catch (e) {
+        console.error(e);
+      }
     },
     validate: ({ title, image, content, channelId }) => {
       const error = {};

--- a/src/pages/Post/WritingPostPage.js
+++ b/src/pages/Post/WritingPostPage.js
@@ -133,7 +133,7 @@ const WritingPostPage = () => {
           label="제목"
           wrapperStyles={{
             display: "flex",
-            "flex-direction": "column",
+            flexDirection: "column",
             gap: "24px",
           }}
           inputStyles={{

--- a/src/utils/apis/posts.js
+++ b/src/utils/apis/posts.js
@@ -81,7 +81,12 @@ const useDeletePostById = ({ id, token }) =>
     }),
   );
 
-const createPost = async ({ title, image, channelId, token }) => {
+const createPost = async ({
+  title = "",
+  image = null,
+  channelId = "",
+  token = "",
+}) => {
   const formData = new FormData();
 
   formData.append("title", title);


### PR DESCRIPTION
# 개요

글 작성 페이지 라우팅 적용

# 작업 내용

- App.js 에서 `path="write"` 에 라우팅
- 글 작성 취소시 메인페이지로 이동 `replace:false`
- 글 작성 완료 후 에러 없으면 메인 페이지로 이동 `replace:true`
- creatPost 파라미터 기본값 설정

# 사진
<img width="1440" alt="스크린샷 2022-06-19 오전 12 12 47" src="https://user-images.githubusercontent.com/16220817/174444763-15437494-c292-4d97-8767-35a5fe4703ed.png">
<img width="1440" alt="스크린샷 2022-06-19 오전 12 12 56" src="https://user-images.githubusercontent.com/16220817/174444772-f6aad52a-cce7-4950-80e8-80a1735cd332.png">


# 중점적으로 봐줬으면 하는 부분 (선택 사항)
