### PR TITLE
Feature/#78-로그인 페이지 라우팅 적용

### DIFF
--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -49,16 +49,20 @@ const Login = () => {
     //   await handleLogin(userInfo);
     // },
     onSubmit: async ({ email, password }) => {
-      const { data } = await axios({
-        method: "POST",
-        url: "/login",
-        data: {
-          email,
-          password,
-        },
-      });
-      console.log(data);
-      setUser(data);
+      try {
+        const { data } = await axios({
+          method: "POST",
+          url: "/login",
+          data: {
+            email,
+            password,
+          },
+        });
+
+        setUser(data);
+      } catch (e) {
+        console.error(e);
+      }
     },
     validate: ({ email, password }) => {
       const newErrors = {};

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -64,7 +64,7 @@ const Login = () => {
         setUser(data);
         navigate("/", { replace: true });
       } catch (e) {
-        console.error(e);
+        alert(`로그인 실패.\n ${e}`);
       }
     },
     validate: ({ email, password }) => {

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -1,4 +1,3 @@
-// import PropTypes from "prop-types";
 import styled from "@emotion/styled";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
@@ -47,9 +46,6 @@ const Login = () => {
       email: "",
       password: "",
     },
-    // onSubmit: async userInfo => {
-    //   await handleLogin(userInfo);
-    // },
     onSubmit: async ({ email, password }) => {
       try {
         const { data } = await axios({
@@ -130,9 +126,5 @@ const Login = () => {
     </CardForm>
   );
 };
-
-// Login.propTypes = {
-//   onSubmit: PropTypes.func,
-// };
 
 export default Login;

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -1,6 +1,7 @@
 // import PropTypes from "prop-types";
 import styled from "@emotion/styled";
 import axios from "axios";
+import { useNavigate } from "react-router-dom";
 import Text from "../../components/Text/Text";
 import Input from "../../components/Input/Input";
 import Button from "../../components/Button/Button";
@@ -40,6 +41,7 @@ const ButtonWrapper = styled.div`
 
 const Login = () => {
   const { setUser } = useGlobalContext();
+  const navigate = useNavigate();
   const { errors, isLoading, handleChange, handleSubmit } = useForm({
     initialValues: {
       email: "",
@@ -60,6 +62,7 @@ const Login = () => {
         });
 
         setUser(data);
+        navigate("/", { replace: true });
       } catch (e) {
         console.error(e);
       }

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -121,6 +121,7 @@ const Login = () => {
             type="submit"
             disabled={isLoading}
             style={{ marginLeft: "16px" }}
+            onClick={() => navigate("/signup")}
           >
             회원가입
           </Button>


### PR DESCRIPTION
# 개요

로그인 페이지 라우팅 적용

# 작업 내용

- 로그인 성공시 메인 페이지로 이동
- 회원가입 버튼 클릭시 회원가입 페이지로 이동
- 로그인 실패시 alert 발생

# 사진
<img width="1440" alt="스크린샷 2022-06-19 오전 12 57 47" src="https://user-images.githubusercontent.com/16220817/174446717-85b33f24-1e10-4716-a540-05b724e61dc2.png">
<img width="1440" alt="스크린샷 2022-06-19 오전 12 57 59" src="https://user-images.githubusercontent.com/16220817/174446720-ca441e41-95cb-46ea-a1b0-3ea6813cce60.png">
<img width="1440" alt="스크린샷 2022-06-19 오전 12 58 20" src="https://user-images.githubusercontent.com/16220817/174446721-80a58f43-608f-46d4-8da4-4a94014cb42a.png">


# 중점적으로 봐줬으면 하는 부분 (선택 사항)
