### PR TITLE
Feature/#68 무한스크롤 적용

### DIFF
--- a/src/hooks/useInfiniteScroll.js
+++ b/src/hooks/useInfiniteScroll.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+const useInfiniteScroll = ({ onIntersecting, options }) => {
+  const [lastIntersectingImage, setLastIntersectingImage] = useState(null);
+  const onIntersect = entries => {
+    if (!entries) {
+      return;
+    }
+
+    if (entries[0].isIntersecting) {
+      onIntersecting();
+    }
+  };
+  useEffect(() => {
+    let observer;
+    if (lastIntersectingImage) {
+      observer = new IntersectionObserver(onIntersect, options);
+      observer.observe(lastIntersectingImage);
+    }
+    return () => observer && observer.disconnect();
+  }, [lastIntersectingImage]);
+
+  return { setLastIntersectingImage };
+};
+
+export default useInfiniteScroll;

--- a/src/pages/MainPage/MainPage.js
+++ b/src/pages/MainPage/MainPage.js
@@ -65,8 +65,8 @@ export default function MainPage() {
     onIntersecting,
     options: { threshold: 0.3 },
   });
-  const { data } = useGetPosts({ chanelId: channelId, offset, limit: LIMIT });
-  const { data: total } = useGetPosts({ chanelId: channelId, key: "total" });
+  const { data } = useGetPosts({ channelId, offset, limit: LIMIT });
+  const { data: total } = useGetPosts({ channelId, key: "total" });
   const { state } = useGlobalContext();
   useEffect(() => {
     if (!data) {

--- a/src/pages/MainPage/MainPage.js
+++ b/src/pages/MainPage/MainPage.js
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Edit, ArrowUp } from "react-feather";
 import { useNavigate } from "react-router-dom";
 import UpperHeader from "../../components/Header/UpperHeader";
@@ -10,6 +10,7 @@ import Button from "../../components/Button/Button";
 import Footer from "../../components/Footer/Footer";
 import Modal from "../../components/Modal/Modal";
 import DetailPage from "../../components/DetailPage/DetailPage";
+import useInfiniteScroll from "../../hooks/useInfiniteScroll";
 import { useGetPosts } from "../../utils/apis/posts";
 import { useGlobalContext } from "../../store/GlobalProvider";
 
@@ -46,15 +47,40 @@ export default function MainPage() {
     document.documentElement.scrollTo({ top: 0, behavior: "smooth" });
   };
 
+  const LIMIT = 4;
   const [channelId, setChannelId] = useState("");
   const [postArr, setPostArr] = useState([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedPost, setSeletedPost] = useState(null);
-  const { data } = useGetPosts({ chanelId: channelId });
+  const [offset, setOffset] = useState(0);
+  const [totalCount, setTotalCount] = useState(LIMIT);
+
+  const onIntersecting = useCallback(() => {
+    if (postArr.length >= totalCount) {
+      return;
+    }
+    setOffset(offset + LIMIT);
+  }, [setOffset, offset, totalCount]);
+  const { setLastIntersectingImage } = useInfiniteScroll({
+    onIntersecting,
+    options: { threshold: 0.3 },
+  });
+  const { data } = useGetPosts({ chanelId: channelId, offset, limit: LIMIT });
+  const { data: total } = useGetPosts({ chanelId: channelId, key: "total" });
   const { state } = useGlobalContext();
   useEffect(() => {
-    setPostArr(data);
+    if (!data) {
+      return;
+    }
+    setPostArr([...postArr, ...data]);
   }, [data]);
+
+  useEffect(() => {
+    if (!total) {
+      return;
+    }
+    setTotalCount(total.length);
+  }, [total]);
 
   const handleLikes = (likes, postId) => {
     const tempPost = postArr.map(post =>
@@ -73,21 +99,40 @@ export default function MainPage() {
         <Carousel second={5000} height={300} />
         <ContentDiv>
           {postArr
-            ? postArr.map(e => (
-                <StyledCard
-                  width={250}
-                  title={e.title}
-                  userName={e.author.fullName}
-                  likeCount={e.likes.length}
-                  commentCount={e.comments.length}
-                  date={e.createdAt.slice(0, 10)}
-                  key={e._id}
-                  onClick={() => {
-                    setIsModalOpen(true);
-                    setSeletedPost(e);
-                  }}
-                />
-              ))
+            ? postArr.map((e, index) => {
+                const isLast = index === postArr.length - 1;
+                return isLast ? (
+                  <div ref={setLastIntersectingImage} key={e._id}>
+                    <StyledCard
+                      width={250}
+                      title={e.title}
+                      userName={e.author.fullName}
+                      likeCount={e.likes.length}
+                      commentCount={e.comments.length}
+                      date={e.createdAt.slice(0, 10)}
+                      key={e._id}
+                      onClick={() => {
+                        setIsModalOpen(true);
+                        setSeletedPost(e);
+                      }}
+                    />
+                  </div>
+                ) : (
+                  <StyledCard
+                    width={250}
+                    title={e.title}
+                    userName={e.author.fullName}
+                    likeCount={e.likes.length}
+                    commentCount={e.comments.length}
+                    date={e.createdAt.slice(0, 10)}
+                    key={e._id}
+                    onClick={() => {
+                      setIsModalOpen(true);
+                      setSeletedPost(e);
+                    }}
+                  />
+                );
+              })
             : null}
         </ContentDiv>
         {state.userInfo ? (

--- a/src/stories/hooks/useInfiniteScroll.stories.js
+++ b/src/stories/hooks/useInfiniteScroll.stories.js
@@ -1,0 +1,65 @@
+import styled from "@emotion/styled";
+import { useCallback, useEffect, useState } from "react";
+import { useGetPosts } from "../../utils/apis/posts";
+import useInfiniteScroll from "../../hooks/useInfiniteScroll";
+
+export default {
+  title: "Hook/useInfiniteScroll",
+  component: useInfiniteScroll,
+  argTypes: {},
+};
+
+const Card = styled.div`
+  width: 300px;
+  height: 300px;
+  border: solid 2px;
+`;
+
+export const Default = () => {
+  const [offset, setOffset] = useState(0);
+  const [result, setResult] = useState([]);
+  const limit = 2;
+  const channelId = "62aac619584e72755a79fcfc";
+  const onIntersecting = useCallback(
+    () => setOffset(offset + limit),
+    [setOffset, offset],
+  );
+  const { setLastIntersectingImage } = useInfiniteScroll({
+    onIntersecting,
+    options: { threshold: 0.3 },
+  });
+
+  const { data } = useGetPosts({
+    chanelId: channelId,
+    offset,
+    limit,
+  });
+
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+
+    setResult([...result, ...data]);
+  }, [data]);
+
+  return (
+    <>
+      <div style={{ height: "400px", backgroundColor: "red" }}>박스</div>
+      <ul>
+        {result.length > 0 &&
+          result.map(({ title, _id }, index) =>
+            index === result.length - 1 ? (
+              <li ref={setLastIntersectingImage} key={_id}>
+                <Card>{title}</Card>
+              </li>
+            ) : (
+              <li key={_id}>
+                <Card>{title}</Card>
+              </li>
+            ),
+          )}
+      </ul>
+    </>
+  );
+};

--- a/src/stories/hooks/useInfiniteScroll.stories.js
+++ b/src/stories/hooks/useInfiniteScroll.stories.js
@@ -18,7 +18,7 @@ const Card = styled.div`
 export const Default = () => {
   const [offset, setOffset] = useState(0);
   const [result, setResult] = useState([]);
-  const limit = 2;
+  const limit = 4;
   const channelId = "62aac619584e72755a79fcfc";
   const onIntersecting = useCallback(
     () => setOffset(offset + limit),
@@ -30,7 +30,7 @@ export const Default = () => {
   });
 
   const { data } = useGetPosts({
-    chanelId: channelId,
+    channelId,
     offset,
     limit,
   });

--- a/src/utils/apis/posts.js
+++ b/src/utils/apis/posts.js
@@ -3,7 +3,7 @@ import axios from "axios";
 
 const useGetPosts = ({ chanelId, offset = 0, limit = 10 }) =>
   useQuery(
-    `/posts/channel/${chanelId}`,
+    [`/posts/channel/${chanelId}`, offset],
     async () => {
       const { data } = await axios.get(`/posts/channel/${chanelId}`, {
         params: { offset, limit },

--- a/src/utils/apis/posts.js
+++ b/src/utils/apis/posts.js
@@ -1,17 +1,17 @@
 import { useQuery } from "react-query";
 import axios from "axios";
 
-const useGetPosts = ({ chanelId, offset = 0, limit, key = "" }) =>
+const useGetPosts = ({ channelId, offset = 0, limit, key = "" }) =>
   useQuery(
-    [`/posts/channel/${chanelId}${key}`, offset],
+    [`/posts/channel/${channelId}${key}`, offset],
     async () => {
-      const { data } = await axios.get(`/posts/channel/${chanelId}`, {
+      const { data } = await axios.get(`/posts/channel/${channelId}`, {
         params: limit ? { offset, limit } : { offset },
       });
       return data;
     },
     {
-      enabled: !!chanelId,
+      enabled: !!channelId,
     },
   );
 

--- a/src/utils/apis/posts.js
+++ b/src/utils/apis/posts.js
@@ -1,12 +1,12 @@
 import { useQuery } from "react-query";
 import axios from "axios";
 
-const useGetPosts = ({ chanelId, offset = 0, limit = 10 }) =>
+const useGetPosts = ({ chanelId, offset = 0, limit, key = "" }) =>
   useQuery(
-    [`/posts/channel/${chanelId}`, offset],
+    [`/posts/channel/${chanelId}${key}`, offset],
     async () => {
       const { data } = await axios.get(`/posts/channel/${chanelId}`, {
-        params: { offset, limit },
+        params: limit ? { offset, limit } : { offset },
       });
       return data;
     },


### PR DESCRIPTION
# 개요

무한 스크롤 적용

# 작업 내용

- useInfiniteScroll 구현
- 메인페이지에 무한 스크롤 적용
- useGetPosts에 offset 의존성 추가
- useGetPosts 오타 수정

# 사진
<img width="1440" alt="스크린샷 2022-06-20 오후 4 56 53" src="https://user-images.githubusercontent.com/16220817/174553168-3c9eb00c-796f-4bb4-85f7-193fe04c2700.png">
<img width="1440" alt="스크린샷 2022-06-20 오후 4 57 04" src="https://user-images.githubusercontent.com/16220817/174553180-c86b4dd2-d9fb-43fb-b07b-91bf7d45af18.png">


# 중점적으로 봐줬으면 하는 부분 (선택 사항)

Card에 ref 연결이 잘안되서 마지막 카드에만 div로 감싸서 ref 연결했습니다.