### PR TITLE
Feature/#106-글 작성페이지 이미지 리렌더링 수정 및 UI 수정

### DIFF
--- a/src/components/ImageUpload/ImageUpload.js
+++ b/src/components/ImageUpload/ImageUpload.js
@@ -4,6 +4,12 @@ import PropTypes from "prop-types";
 import PreviewImage from "./PreviewImage";
 import Image from "../Image/Image";
 
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+`;
 const UploadContainer = styled.div`
   display: inline-flex;
   cursor: pointer;
@@ -18,6 +24,7 @@ const reader = new FileReader();
 const ImageUpload = ({
   isInnerPreview = false,
   children,
+  wrapperStyles,
   previewImageWrapperStyles,
   previewImageStyles,
   name,
@@ -61,7 +68,7 @@ const ImageUpload = ({
   };
 
   return (
-    <>
+    <Wrapper style={wrapperStyles}>
       <UploadContainer onClick={handleChooseFile} {...props}>
         <Input
           ref={inputRef}
@@ -88,15 +95,16 @@ const ImageUpload = ({
           previewItem={previewItem}
         />
       )}
-    </>
+    </Wrapper>
   );
 };
 
 ImageUpload.propTypes = {
   isInnerPreview: PropTypes.bool,
   children: PropTypes.node,
-  previewImageWrapperStyles: PropTypes.shape(),
-  previewImageStyles: PropTypes.shape(),
+  wrapperStyles: PropTypes.objectOf(PropTypes.string),
+  previewImageWrapperStyles: PropTypes.objectOf(PropTypes.string),
+  previewImageStyles: PropTypes.objectOf(PropTypes.string),
   name: PropTypes.string,
 };
 

--- a/src/components/ImageUpload/ImageUpload.js
+++ b/src/components/ImageUpload/ImageUpload.js
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import PreviewImage from "./PreviewImage";
 import Image from "../Image/Image";
@@ -100,4 +100,4 @@ ImageUpload.propTypes = {
   name: PropTypes.string,
 };
 
-export default ImageUpload;
+export default React.memo(ImageUpload);

--- a/src/components/ImageUpload/PreviewImage.js
+++ b/src/components/ImageUpload/PreviewImage.js
@@ -14,6 +14,7 @@ const PreviewImage = ({ children, previewImageWrapperStyles, previewItem }) => {
     border-radius: 15px;
     box-sizing: border-box;
   `;
+  console.log(previewImageWrapperStyles);
 
   return children ? (
     React.cloneElement(children, null, [previewItem])

--- a/src/components/ImageUpload/PreviewImage.js
+++ b/src/components/ImageUpload/PreviewImage.js
@@ -18,7 +18,9 @@ const PreviewImage = ({ children, previewImageWrapperStyles, previewItem }) => {
   return children ? (
     React.cloneElement(children, null, [previewItem])
   ) : (
-    <PreviewImageWrapper style={previewImageWrapperStyles}>{previewItem}</PreviewImageWrapper>
+    <PreviewImageWrapper style={previewImageWrapperStyles}>
+      {previewItem}
+    </PreviewImageWrapper>
   );
 };
 
@@ -28,4 +30,4 @@ PreviewImage.propTypes = {
   previewItem: PropTypes.node,
 };
 
-export default PreviewImage;
+export default React.memo(PreviewImage);

--- a/src/components/ImageUpload/PreviewImage.js
+++ b/src/components/ImageUpload/PreviewImage.js
@@ -2,28 +2,26 @@ import styled from "@emotion/styled";
 import PropTypes from "prop-types";
 import React from "react";
 
-const PreviewImage = ({ children, previewImageWrapperStyles, previewItem }) => {
-  const PreviewImageWrapper = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 40px;
-    padding-left: 40px;
-    background-color: #d9d9d9;
-    width: 100%;
-    height: 245px;
-    border-radius: 15px;
-    box-sizing: border-box;
-  `;
-  console.log(previewImageWrapperStyles);
+const PreviewImageWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 40px;
+  padding-left: 40px;
+  background-color: #d9d9d9;
+  width: 100%;
+  height: 245px;
+  border-radius: 15px;
+  box-sizing: border-box;
+`;
 
-  return children ? (
+const PreviewImage = ({ children, previewImageWrapperStyles, previewItem }) =>
+  children ? (
     React.cloneElement(children, null, [previewItem])
   ) : (
     <PreviewImageWrapper style={previewImageWrapperStyles}>
       {previewItem}
     </PreviewImageWrapper>
   );
-};
 
 PreviewImage.propTypes = {
   children: PropTypes.node,

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -23,6 +23,7 @@ const StyledSelect = styled.select`
   border: 1px solid ${({ invalid }) => (invalid ? "red" : "gray")};
   border-radius: 15px;
   box-sizing: border-box;
+  font-size: 32px;
 `;
 
 const Select = ({

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -13,14 +13,15 @@ const Label = styled.label`
   flex-shrink: 0;
   font-size: 36px;
   font-weight: 700;
-  line-height: 32px;
+  line-height: 34px;
 `;
 
 const StyledSelect = styled.select`
   width: 100%;
+  height: 40px;
   padding: 4px 8px;
   border: 1px solid ${({ invalid }) => (invalid ? "red" : "gray")};
-  border-radius: 4px;
+  border-radius: 15px;
   box-sizing: border-box;
 `;
 

--- a/src/pages/Post/WritingPostPage.js
+++ b/src/pages/Post/WritingPostPage.js
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { Camera } from "react-feather";
 import Modal from "../../components/Modal/Modal";
 import Button from "../../components/Button/Button";
 import UpperHeader from "../../components/Header/UpperHeader";
@@ -25,13 +26,18 @@ const Label = styled.label`
   font-size: 36px;
   font-weight: 700;
   line-height: 32px;
-  cursor: pointer;
 `;
 
-const AddWrapper = styled.label`
-  display: inline-flex;
-  align-items: flex-end;
-  gap: 24px;
+const ImageUploadWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 40px;
+  padding-left: 40px;
+  background-color: #d9d9d9;
+  width: 100%;
+  height: 245px;
+  border-radius: 15px;
+  box-sizing: border-box;
 `;
 
 const StyledTextArea = styled.textarea`
@@ -146,18 +152,30 @@ const WritingPostPage = () => {
           name="title"
           onChange={handleChange}
         />
-        <ImageUpload
-          name="image"
-          previewImageStyles={{ width: "160px", height: "200px" }}
-          onChange={handleChange}
-        >
-          <AddWrapper>
-            <Label>사진</Label>
-            <Button height="32px" backgroundColor="transparent" color="black">
-              +
+        <Label>사진</Label>
+        <ImageUploadWrapper>
+          <ImageUpload
+            name="image"
+            wrapperStyles={{
+              flexDirection: "row",
+              alignItems: "center",
+              width: "100%",
+              height: "100%",
+            }}
+            previewImageStyles={{ height: "80%" }}
+            previewImageWrapperStyles={{
+              backgroundColor: "transparent",
+              width: "100%",
+              aspectRatio: "4 / 5",
+            }}
+            style={{ height: "80%", aspectRatio: "1 / 1" }}
+            onChange={handleChange}
+          >
+            <Button width="100%" height="100%" borderRadius="100%">
+              <Camera size={100} />
             </Button>
-          </AddWrapper>
-        </ImageUpload>
+          </ImageUpload>
+        </ImageUploadWrapper>
         <Label>피드백 받고 싶은 내용을 적어주세요.</Label>
         <StyledTextArea name="content" onChange={handleChange} />
         <SubmitWrapper>


### PR DESCRIPTION
# 개요

글 작성페이지 이미지 리렌더링 수정 및 UI 수정

# 작업 내용

- useMemo, 컴포넌트 안 Wrapper -> 컴포넌트 밖으로 수정해서 타이핑시 이미지 리렌더링 해결
- 사진 추가 버튼 UI 변경
- Select 크기 변경

# 사진
<img width="1440" alt="스크린샷 2022-06-20 오후 11 09 33" src="https://user-images.githubusercontent.com/16220817/174620386-93738e38-1bba-4d8c-9b09-e18055be0b42.png">


# 중점적으로 봐줬으면 하는 부분 (선택 사항)
