### PR TITLE
Fix/#119-전역상태 준비 후 라우팅 및 중복 라우팅 제거

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,9 +38,12 @@ function App() {
     setUser({ user: authUser, token: storedToken });
   }, [authUser]);
 
+  const NO_TOKEN = "";
   const NO_AUTH_USER = "";
   const isReadyState =
-    (authUser && state.userInfo !== null) || authUser === NO_AUTH_USER;
+    storedToken === NO_TOKEN ||
+    (authUser && state.userInfo !== null) ||
+    authUser === NO_AUTH_USER;
 
   return (
     <div className="App">

--- a/src/App.js
+++ b/src/App.js
@@ -21,10 +21,10 @@ import SearchPage from "./pages/Search/SearchPage";
 axios.defaults.baseURL = `http://kdt.frontend.2nd.programmers.co.kr:5006`;
 
 function App() {
-  const { storedToken, setChannels, setUser } = useGlobalContext();
+  const { state, storedToken, setChannels, setUser } = useGlobalContext();
   const { data: channels } = useGetChannelList();
 
-  const { data: userInfo } = useGetAuthUser({ token: storedToken });
+  const { data: authUser } = useGetAuthUser({ token: storedToken });
 
   useEffect(() => {
     if (!channels) return;
@@ -33,35 +33,40 @@ function App() {
   }, [channels]);
 
   useEffect(() => {
-    if (!userInfo) return;
+    if (!authUser) return;
 
-    setUser({ user: userInfo, token: storedToken });
-  }, [userInfo]);
+    setUser({ user: authUser, token: storedToken });
+  }, [authUser]);
+
+  const NO_AUTH_USER = "";
+  const isReadyState =
+    (authUser && state.userInfo !== null) || authUser === NO_AUTH_USER;
 
   return (
     <div className="App">
       <Global styles={[resetStyle, globalStyle]} />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<MainPage />} />
-          <Route path="login" element={<Login />} />
-          <Route path="signup" element={<SignUp />} />
-          <Route path="write" element={<WritingPostPage />} />
-          <Route path="profile" element={<Profile />} />
-          <Route path="update-profile" element={<UpdateProfile />} />
-          <Route path="alarm" element={<AlarmPage />} />
-          <Route path="search" element={<SearchPage />} />
-          <Route
-            path="write"
-            element={
-              <ProtectedRoute>
-                <WritingPostPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route path="*" element={<NotFoundPage />} />
-        </Routes>
-      </BrowserRouter>
+      {isReadyState ? (
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<MainPage />} />
+            <Route path="login" element={<Login />} />
+            <Route path="signup" element={<SignUp />} />
+            <Route
+              path="write"
+              element={
+                <ProtectedRoute>
+                  <WritingPostPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route path="profile" element={<Profile />} />
+            <Route path="update-profile" element={<UpdateProfile />} />
+            <Route path="alarm" element={<AlarmPage />} />
+            <Route path="search" element={<SearchPage />} />
+            <Route path="*" element={<NotFoundPage />} />
+          </Routes>
+        </BrowserRouter>
+      ) : null}
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -60,8 +60,22 @@ function App() {
               }
             />
             <Route path="profile" element={<Profile />} />
-            <Route path="update-profile" element={<UpdateProfile />} />
-            <Route path="alarm" element={<AlarmPage />} />
+            <Route
+              path="update-profile"
+              element={
+                <ProtectedRoute>
+                  <UpdateProfile />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="alarm"
+              element={
+                <ProtectedRoute>
+                  <AlarmPage />
+                </ProtectedRoute>
+              }
+            />
             <Route path="search" element={<SearchPage />} />
             <Route path="*" element={<NotFoundPage />} />
           </Routes>

--- a/src/store/GlobalProvider.js
+++ b/src/store/GlobalProvider.js
@@ -13,7 +13,10 @@ const reducer = (state, action) => {
   switch (action.type) {
     case "SET_USER": {
       // logout 할때
-      if (action.userInfo === null) action.removeStoredToken();
+      if (action.userInfo === null) {
+        action.removeStoredToken();
+        action.setStoredToken("");
+      }
 
       // login 성공해서 token이 return될때
       if (action.userInfo && action.userInfo.token)

--- a/src/utils/apis/auth.js
+++ b/src/utils/apis/auth.js
@@ -2,7 +2,7 @@ import { useQuery } from "react-query";
 import axios from "axios";
 
 const useGetAuthUser = ({ token = "NoToken" }) =>
-  useQuery("/auth-user", async () => {
+  useQuery(["/auth-user", token], async () => {
     const { data } = await axios.get(`/auth-user`, {
       headers: { Authorization: `Bearer ${token}` },
     });


### PR DESCRIPTION
# 개요

전역상태 준비 후 라우팅 및 중복 라우팅 제거

# 작업 내용

- `isReadyState` 상태로 준비되면 라우팅 렌더링
- write 중복 라우팅 제거
- alarm, update-profile 페이지 ProtectedRoute 적용
- 로그아웃시 `storedToken` 빈 문자열로 초기화
- auth-user api 키에 token 값 추가

# 사진
<img width="1440" alt="스크린샷 2022-06-21 오전 11 18 58" src="https://user-images.githubusercontent.com/16220817/174702582-ded76c48-5799-40e6-9e91-f077218c6af5.png">


# 중점적으로 봐줬으면 하는 부분 (선택 사항)

새로고침해서 접속해도 정상 동작합니다~
