### PR TITLE
Fix/#121 게시물, 체형 정보 없는 경우 프로필 레이아웃

### DIFF
--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -59,6 +59,7 @@ const Profile = () => {
   useEffect(() => {
     setPostArr(data);
   }, [data]);
+  console.log(data);
 
   return (
     <>
@@ -147,7 +148,7 @@ const Profile = () => {
         )}
 
         <ContentDiv>
-          {postArr.length > 0 ? (
+          {postArr && postArr.length > 0 ? (
             postArr.map(e => (
               <StyledCard
                 width={250}

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -147,17 +147,26 @@ const Profile = () => {
         )}
 
         <ContentDiv>
-          {postArr
-            ? postArr.map(e => (
-                <StyledCard
-                  width={250}
-                  title={e.title}
-                  likeCount={e.likes.length}
-                  date={e.createdAt.slice(0, 10)}
-                  key={e._id}
-                />
-              ))
-            : null}
+          {postArr.length > 0 ? (
+            postArr.map(e => (
+              <StyledCard
+                width={250}
+                title={e.title}
+                likeCount={e.likes.length}
+                date={e.createdAt.slice(0, 10)}
+                key={e._id}
+              />
+            ))
+          ) : (
+            <Text
+              style={{
+                fontSize: `${Common.fontSize.fs16}`,
+                margin: "0 auto",
+              }}
+            >
+              🥲 게시물이 존재하지 않습니다!
+            </Text>
+          )}
         </ContentDiv>
       </Main>
       <Footer />

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import PropTypes from "prop-types";
+// import PropTypes from "prop-types";
 import styled from "@emotion/styled";
 import { useState, useEffect } from "react";
 import Common from "../../styles/common";
@@ -48,10 +48,12 @@ const StyledCard = styled(Card)`
   margin-bottom: 30px;
 `;
 
-const Profile = ({ authorId }) => {
+const Profile = () => {
   const { state } = useGlobalContext();
-  // const authorId = state.userInfo.user._id;
+  const authorId = state.userInfo.user._id;
   const { data } = useGetPostsByAuthorId({ authorId });
+  const userInfoObj =
+    state.userInfo.user.username && JSON.parse(state.userInfo.user.username);
 
   const [postArr, setPostArr] = useState([]);
   useEffect(() => {
@@ -113,19 +115,23 @@ const Profile = ({ authorId }) => {
           <Text bold="true" size={`${Common.fontSize.fs16}`}>
             {state.userInfo.user.fullName}
           </Text>
-          <span style={{ margin: "0 5%" }} />
-          <Text
-            bold="true"
-            size={`${Common.fontSize.fs16}`}
-            color="rgba(1,1,1,0.5)"
-          >
-            체형
-          </Text>
-          <span style={{ margin: "1%" }} />
 
-          <Text bold="true" size={`${Common.fontSize.fs16}`}>
-            170cm, 70kg
-          </Text>
+          {state.userInfo.user.username && (
+            <>
+              <span style={{ margin: "0 5%" }} />
+              <Text
+                bold="true"
+                size={`${Common.fontSize.fs16}`}
+                color="rgba(1,1,1,0.5)"
+              >
+                체형
+              </Text>
+              <span style={{ margin: "1%" }} />
+              <Text bold="true" size={`${Common.fontSize.fs16}`}>
+                {userInfoObj.height}cm, {userInfoObj.weight}kg
+              </Text>
+            </>
+          )}
         </FlexDiv>
 
         {state.userInfo ? (
@@ -160,7 +166,7 @@ const Profile = ({ authorId }) => {
 };
 
 Profile.propTypes = {
-  authorId: PropTypes.string,
+  // authorId: PropTypes.string,
 };
 
 export default Profile;


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description -->

# 개요: 프로필 레이아웃 수정


# 작업 내용
- 게시물 없는 경우 '게시물 없음' 표현
- 체형 정보 없는 경우 닉네임 가운데 정렬


# 사진
<img width="1496" alt="스크린샷 2022-06-21 13 17 17" src="https://user-images.githubusercontent.com/67778677/174718953-c2f76eca-fdfe-4553-bf1b-a8e5333de413.png">
<img width="1496" alt="스크린샷 2022-06-21 13 17 35" src="https://user-images.githubusercontent.com/67778677/174718968-e7528dd1-dc15-4484-a0c7-6e07073b8f86.png">

# 중점적으로 봐줬으면 하는 부분 (선택 사항)


