### PR TITLE
Feature/#114-글 수정 페이지 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,7 @@ import ProtectedRoute from "./routes/ProtectedRoute";
 import SearchPage from "./pages/Search/SearchPage";
 import EditPage from "./pages/Post/EditPage";
 
-axios.defaults.baseURL = `http://kdt.frontend.2nd.programmers.co.kr:5006`;
+axios.defaults.baseURL = `https://kdt.frontend.2nd.programmers.co.kr:5006`;
 
 function App() {
   const { state, storedToken, setChannels, setUser } = useGlobalContext();

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ import UpdateProfile from "./pages/UpdateProfile/UpdateProfile";
 import AlarmPage from "./pages/Alarm/AlarmPage";
 import ProtectedRoute from "./routes/ProtectedRoute";
 import SearchPage from "./pages/Search/SearchPage";
+import EditPage from "./pages/Post/EditPage";
 
 axios.defaults.baseURL = `http://kdt.frontend.2nd.programmers.co.kr:5006`;
 
@@ -59,6 +60,14 @@ function App() {
               element={
                 <ProtectedRoute>
                   <WritingPostPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="edit"
+              element={
+                <ProtectedRoute>
+                  <EditPage />
                 </ProtectedRoute>
               }
             />

--- a/src/components/ImageUpload/ImageUpload.js
+++ b/src/components/ImageUpload/ImageUpload.js
@@ -28,6 +28,7 @@ const ImageUpload = ({
   previewImageWrapperStyles,
   previewImageStyles,
   name,
+  prevImageUrl,
   ...props
 }) => {
   const [previewItem, setPreviewItem] = useState(null);
@@ -66,6 +67,16 @@ const ImageUpload = ({
   const handleChooseFile = () => {
     inputRef.current.click();
   };
+
+  useEffect(() => {
+    if (!prevImageUrl) {
+      return;
+    }
+    const prevImage = (
+      <Image alt="사진 미리보기" src={prevImageUrl} {...previewImageStyles} />
+    );
+    setPreviewItem(prevImage);
+  }, [prevImageUrl]);
 
   return (
     <Wrapper style={wrapperStyles}>
@@ -106,6 +117,7 @@ ImageUpload.propTypes = {
   previewImageWrapperStyles: PropTypes.objectOf(PropTypes.string),
   previewImageStyles: PropTypes.objectOf(PropTypes.string),
   name: PropTypes.string,
+  prevImageUrl: PropTypes.string,
 };
 
 export default React.memo(ImageUpload);

--- a/src/pages/Post/EditPage.js
+++ b/src/pages/Post/EditPage.js
@@ -1,0 +1,229 @@
+import styled from "@emotion/styled";
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Camera } from "react-feather";
+import Modal from "../../components/Modal/Modal";
+import Button from "../../components/Button/Button";
+import UpperHeader from "../../components/Header/UpperHeader";
+import ImageUpload from "../../components/ImageUpload/ImageUpload";
+import Input from "../../components/Input/Input";
+import useForm from "../../hooks/useForm";
+import { useGlobalContext } from "../../store/GlobalProvider";
+import Select from "../../components/Select/Select";
+import Footer from "../../components/Footer/Footer";
+import { updatePost } from "../../utils/apis/posts";
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin: 32px 15%;
+`;
+
+const Label = styled.label`
+  display: block;
+  flex-shrink: 0;
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 32px;
+`;
+
+const ImageUploadWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 40px;
+  padding-left: 40px;
+  background-color: #d9d9d9;
+  width: 100%;
+  height: 245px;
+  border-radius: 15px;
+  box-sizing: border-box;
+`;
+
+const StyledTextArea = styled.textarea`
+  width: 100%;
+  height: 240px;
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 32px;
+  background-color: #d9d9d9;
+  border-radius: 15px;
+  border: none;
+  resize: none;
+  box-sizing: border-box;
+`;
+
+const SubmitWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 24px;
+  width: 100%;
+`;
+
+const EditPage = () => {
+  const { state, storedToken } = useGlobalContext();
+  const navigate = useNavigate();
+  const goMainPage = ({ replace = false }) => navigate("/", { replace });
+  const { state: locationState } = useLocation();
+
+  const post = locationState && locationState.post;
+
+  const deafultTitle = post && post.title ? post.title : "";
+  const defaultContent = post && post.content ? post.content : "";
+  const defaultImage = post && post.image ? post.imgae : "";
+  const defaultChaanelId = post && post.channel ? post.channel._id : "";
+
+  const { errors, handleChange, handleSubmit } = useForm({
+    initialValues: {
+      title: deafultTitle,
+      content: defaultContent,
+      image: defaultImage,
+      channelId: defaultChaanelId,
+    },
+    onSubmit: async ({ title, content, event }) => {
+      // TODO: content 칼럼도 전송하기
+      console.log(`글 작성 등록\n제목: ${title}, 내용: ${content}\n `);
+
+      const changedImgae =
+        event.target.image.files && event.target.image.files[0];
+
+      try {
+        await updatePost({
+          postId: post._id,
+          title,
+          image: changedImgae || post.image,
+          imageToDeletePublicId: null,
+          channelId: post.channel._id,
+          token: storedToken,
+        });
+        goMainPage({ replace: true });
+      } catch (e) {
+        alert(`글 수정 실패 ${e}`);
+      }
+    },
+    validate: ({ title, content, channelId }) => {
+      const error = {};
+      if (!title) {
+        error.title = "제목을 입력해주세요!";
+      }
+      if (!content) {
+        error.content = "내용을 입력해주세요!";
+      }
+      if (!channelId) {
+        error.content = "카테고리를 선택해주세요";
+      }
+      return error;
+    },
+  });
+  const [modalVisible, setModalVisible] = useState(false);
+  const getSelectData = channels =>
+    channels.map(({ name, _id }) => ({ label: name, value: _id }));
+
+  useEffect(() => {
+    if (Object.keys(errors).length > 0) {
+      setModalVisible(true);
+
+      return;
+    }
+
+    setModalVisible(false);
+  }, [errors]);
+
+  useEffect(() => {
+    if (!post) {
+      navigate("/", { replace: true });
+    }
+  }, [post]);
+
+  return (
+    <div>
+      {post ? (
+        <>
+          <UpperHeader />
+          <Form onSubmit={handleSubmit}>
+            <Select
+              label="카테고리"
+              name="channelId"
+              data={
+                state.channels && state.channels.length > 0
+                  ? getSelectData(state.channels)
+                  : []
+              }
+              defaultValue={defaultChaanelId}
+              placeholder="카테고리를 선택해주세요"
+              onChange={handleChange}
+              style={{
+                backgroundColor: "#d9d9d9",
+                border: "none",
+                borderRadius: "15px",
+              }}
+            />
+            <Input
+              label="제목"
+              wrapperStyles={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "24px",
+              }}
+              inputStyles={{
+                border: "none",
+              }}
+              defaultValue={deafultTitle}
+              name="title"
+              onChange={handleChange}
+            />
+            <Label>사진</Label>
+            <ImageUploadWrapper>
+              <ImageUpload
+                name="image"
+                prevImageUrl={post.image}
+                wrapperStyles={{
+                  flexDirection: "row",
+                  alignItems: "center",
+                  width: "100%",
+                  height: "100%",
+                }}
+                previewImageStyles={{ height: "80%" }}
+                previewImageWrapperStyles={{
+                  backgroundColor: "transparent",
+                  width: "100%",
+                  aspectRatio: "4 / 5",
+                }}
+                style={{ height: "80%", aspectRatio: "1 / 1" }}
+                onChange={handleChange}
+              >
+                <Button width="100%" height="100%" borderRadius="100%">
+                  <Camera size={100} />
+                </Button>
+              </ImageUpload>
+            </ImageUploadWrapper>
+            <Label>피드백 받고 싶은 내용을 적어주세요.</Label>
+            <StyledTextArea
+              name="content"
+              defaultValue={defaultContent}
+              onChange={handleChange}
+            />
+            <SubmitWrapper>
+              <Button width="25%" onClick={goMainPage}>
+                취소
+              </Button>
+              <Button type="submit" width="25%">
+                수정 완료
+              </Button>
+            </SubmitWrapper>
+          </Form>
+          <Footer />
+          <Modal
+            width="50%"
+            visible={modalVisible}
+            onClose={() => setModalVisible(false)}
+          >
+            {Object.values(errors)[0]}
+          </Modal>
+        </>
+      ) : null}
+    </div>
+  );
+};
+
+export default EditPage;


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description -->

# 개요
글 수정 페이지 구현

# 작업 내용
- 글 수정 페이지 구현
- ImageUpload에 기존사진 출력하도록 수정
- state에 post 정보없이 페이지 접근하면 메인으로 리다이렉트

# 사진
<img width="1440" alt="스크린샷 2022-06-21 오후 4 21 02" src="https://user-images.githubusercontent.com/16220817/174740801-3536ebe6-cbaa-4dfb-a85a-7d105a3ee4b3.png">
<img width="1440" alt="스크린샷 2022-06-21 오후 4 24 08" src="https://user-images.githubusercontent.com/16220817/174740834-a1ea2785-e9df-4c85-82c1-35a1d9c57581.png">
<img width="1440" alt="스크린샷 2022-06-21 오후 4 24 19" src="https://user-images.githubusercontent.com/16220817/174740843-98017e63-30c3-4890-9536-17f70f5f8176.png">



# 중점적으로 봐줬으면 하는 부분 (선택 사항)
