### PR TITLE
Refactor/#130-메인페이지 title 파싱 추가

### DIFF
--- a/src/pages/MainPage/MainPage.js
+++ b/src/pages/MainPage/MainPage.js
@@ -146,12 +146,20 @@ export default function MainPage() {
         <ContentDiv>
           {postArr.map((e, index) => {
             const isLast = index === postArr.length - 1;
+            let titleContentObject = {};
+            try {
+              titleContentObject = JSON.parse(e.title);
+            } catch (error) {
+              console.error(error);
+              titleContentObject = { title: e.title, content: "" };
+            }
             return (
               <div ref={isLast ? setLastIntersectingImage : null} key={e._id}>
                 <StyledCard
                   width={250}
                   src={e.image}
-                  title={e.title}
+                  title={titleContentObject.title}
+                  content={titleContentObject.content}
                   userName={e.author.fullName}
                   likeCount={e.likes.length}
                   commentCount={e.comments.length}
@@ -159,7 +167,11 @@ export default function MainPage() {
                   key={e._id}
                   onClick={() => {
                     setIsModalOpen(true);
-                    setSeletedPost(e);
+                    setSeletedPost({
+                      ...e,
+                      title: titleContentObject.title,
+                      content: titleContentObject.content,
+                    });
                   }}
                 />
               </div>


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description -->

# 개요

메인페이지 title 파싱 추가

# 작업 내용

- 메인페이지 title 파싱 추가(title, content)
- 파싱 실패시 console.error + title에 값 설정

# 사진
<img width="1440" alt="스크린샷 2022-06-21 오후 8 30 56" src="https://user-images.githubusercontent.com/16220817/174789378-6847ca3d-8171-4924-a262-367b6a0c6e20.png">


# 중점적으로 봐줬으면 하는 부분 (선택 사항)
