### PR TITLE
Fix/#157-프로필 정보 수정 후 현재 유저정보 갱신 문제

### DIFF
--- a/src/pages/UpdateProfile/UpdateProfile.js
+++ b/src/pages/UpdateProfile/UpdateProfile.js
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import axios from "axios";
 import { Save } from "react-feather";
 import UpperHeader from "../../components/Header/UpperHeader";
 // import Image from "../../components/Image/Image";
@@ -10,7 +9,11 @@ import { useGlobalContext } from "../../store/GlobalProvider";
 import useForm from "../../hooks/useForm";
 import parseJsonStringToObject from "../../utils/parseJsonString";
 import ImageUpload from "../../components/ImageUpload/ImageUpload";
-import { updateProfileImage, updateUserInfo } from "../../utils/apis/users";
+import {
+  updateProfileImage,
+  updateUserInfo,
+  updatePassword,
+} from "../../utils/apis/users";
 
 const Header = styled.header`
   position: sticky;
@@ -178,14 +181,8 @@ const UpdateProfile = () => {
     },
     onSubmit: async ({ password }) => {
       try {
-        await axios({
-          method: "PUT",
-          url: "/settings/update-password",
-          headers: { Authorization: `Bearer ${storedToken}` },
-          data: {
-            password,
-          },
-        });
+        await updatePassword({ password, token: storedToken });
+
         alert("비밀번호를 변경했습니다.");
       } catch (e) {
         alert(`비밀번호 변경 실패.\n ${e}`);

--- a/src/pages/UpdateProfile/UpdateProfile.js
+++ b/src/pages/UpdateProfile/UpdateProfile.js
@@ -137,7 +137,7 @@ const UpdateProfile = () => {
           weight,
           age,
         });
-        await axios({
+        const { data: nextUser } = await axios({
           method: "PUT",
           url: "/settings/update-user",
           headers: { Authorization: `Bearer ${storedToken}` },
@@ -146,6 +146,8 @@ const UpdateProfile = () => {
             username: userInfoString,
           },
         });
+
+        setUser({ user: nextUser, token: storedToken });
         alert("회원정보를 변경했습니다.");
       } catch (e) {
         alert(`회원정보 변경 실패.\n ${e}`);

--- a/src/pages/UpdateProfile/UpdateProfile.js
+++ b/src/pages/UpdateProfile/UpdateProfile.js
@@ -10,7 +10,7 @@ import { useGlobalContext } from "../../store/GlobalProvider";
 import useForm from "../../hooks/useForm";
 import parseJsonStringToObject from "../../utils/parseJsonString";
 import ImageUpload from "../../components/ImageUpload/ImageUpload";
-import { updateProfileImage } from "../../utils/apis/users";
+import { updateProfileImage, updateUserInfo } from "../../utils/apis/users";
 
 const Header = styled.header`
   position: sticky;
@@ -132,19 +132,14 @@ const UpdateProfile = () => {
     },
     onSubmit: async ({ fullName, height, weight, age }) => {
       try {
-        const userInfoString = JSON.stringify({
-          height,
-          weight,
-          age,
-        });
-        const { data: nextUser } = await axios({
-          method: "PUT",
-          url: "/settings/update-user",
-          headers: { Authorization: `Bearer ${storedToken}` },
-          data: {
-            fullName,
-            username: userInfoString,
-          },
+        const nextUser = await updateUserInfo({
+          fullName,
+          username: JSON.stringify({
+            height,
+            weight,
+            age,
+          }),
+          token: storedToken,
         });
 
         setUser({ user: nextUser, token: storedToken });

--- a/src/utils/apis/users.js
+++ b/src/utils/apis/users.js
@@ -84,6 +84,16 @@ const updateUserInfo = async ({ fullName, username, token }) => {
   return data;
 };
 
+const updatePassword = async ({ password, token }) =>
+  axios({
+    method: "PUT",
+    url: "/settings/update-password",
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      password,
+    },
+  });
+
 export {
   useGetUsers,
   useLogin,
@@ -92,4 +102,5 @@ export {
   useGetUser,
   updateProfileImage,
   updateUserInfo,
+  updatePassword,
 };

--- a/src/utils/apis/users.js
+++ b/src/utils/apis/users.js
@@ -70,6 +70,20 @@ const updateProfileImage = async ({ image = "", token = "" }) => {
   return data;
 };
 
+const updateUserInfo = async ({ fullName, username, token }) => {
+  const { data } = await axios({
+    method: "PUT",
+    url: "/settings/update-user",
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      fullName,
+      username,
+    },
+  });
+
+  return data;
+};
+
 export {
   useGetUsers,
   useLogin,
@@ -77,4 +91,5 @@ export {
   useSignup,
   useGetUser,
   updateProfileImage,
+  updateUserInfo,
 };


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description -->

# 개요

프로필 정보 수정 후 현재 유저정보 갱신 문제 해결


# 작업 내용

- 유저정보 변경 후 응답한 유저정보 state에 저장
- 유저정보, 비밀번호 변경 api 함수화

# 사진
<img width="1440" alt="스크린샷 2022-06-22 오전 10 52 42" src="https://user-images.githubusercontent.com/16220817/174926588-673e88ff-9f0c-47a3-bac3-bc97d0244e4d.png">
<img width="1440" alt="스크린샷 2022-06-22 오전 10 52 55" src="https://user-images.githubusercontent.com/16220817/174926598-69ea5b0b-2da7-4597-a7f5-20d9186f5dca.png">


# 중점적으로 봐줬으면 하는 부분 (선택 사항)
