### PR TITLE
Refactor/#159 렌더링시 프로필 이미지 적용하기

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -3,6 +3,7 @@ import { Heart, MessageSquare } from "react-feather";
 import styled from "@emotion/styled";
 import Image from "../Image/Image";
 import Text from "../Text/Text";
+import DEFAULT_PROFILE_IMAGE_URL from "../../utils/constants";
 
 const Wrapper = styled.div`
   border: 1px solid #d9d9d9;
@@ -38,7 +39,7 @@ const SocialWrapper = styled.div`
 
 export default function Card({
   src = "https://picsum.photos/200",
-  profileImg = "https://picsum.photos/200",
+  profileImg = DEFAULT_PROFILE_IMAGE_URL,
   date = "22.06.13",
   userName = "루카스팀",
   title = "fashion feedback",

--- a/src/components/Comments/Comments.js
+++ b/src/components/Comments/Comments.js
@@ -9,6 +9,7 @@ import Button from "../Button/Button";
 import { useGlobalContext } from "../../store/GlobalProvider";
 import { createComment, deleteComment } from "../../utils/apis/comments";
 import { useCreateAlarm } from "../../utils/apis/notifications";
+import DEFAULT_PROFILE_IMAGE_URL from "../../utils/constants";
 
 const CommentsContainer = styled.div`
   overflow: auto;
@@ -92,7 +93,7 @@ const Comments = ({ comments, postId, onHandlePost, userId }) => {
       {comments.map(comment => (
         <CommentWrapper key={comment._id}>
           <Image
-            src="https://picsum.photos/100"
+            src={comment.author.image || DEFAULT_PROFILE_IMAGE_URL}
             width={30}
             height={30}
             style={{ borderRadius: "50%", marginRight: "10px" }}

--- a/src/components/DetailPage/DetailPage.js
+++ b/src/components/DetailPage/DetailPage.js
@@ -1,3 +1,4 @@
+import React from "react";
 import styled from "@emotion/styled";
 import PropTypes from "prop-types";
 import { useNavigate } from "react-router-dom";
@@ -9,6 +10,7 @@ import Button from "../Button/Button";
 import Likes from "../Likes/Likes";
 import Comments from "../Comments/Comments";
 import { deletePost } from "../../utils/apis/posts";
+import DEFAULT_PROFILE_IMAGE_URL from "../../utils/constants";
 
 const PageContainer = styled.div`
   display: flex;
@@ -98,7 +100,7 @@ const DetailPage = ({ post, onHandlePost, onDeletePost }) => {
         <ContentContainer>
           <ProfileContainer>
             <Image
-              src="https://picsum.photos/100"
+              src={post.author.image || DEFAULT_PROFILE_IMAGE_URL}
               width={40}
               height={40}
               style={{ borderRadius: "50%", marginRight: "5px" }}
@@ -198,6 +200,7 @@ DetailPage.propTypes = {
     content: PropTypes.string,
     author: PropTypes.shape({
       fullName: PropTypes.string,
+      image: PropTypes.string,
       _id: PropTypes.string,
     }),
     createdAt: PropTypes.string,
@@ -208,4 +211,4 @@ DetailPage.propTypes = {
   onDeletePost: PropTypes.func,
 };
 
-export default DetailPage;
+export default React.memo(DetailPage);

--- a/src/components/UserSearch/UserSearch.js
+++ b/src/components/UserSearch/UserSearch.js
@@ -21,10 +21,14 @@ const StyledImage = styled(Image)`
   height: 100px;
   border-radius: 100%;
 `;
-export default function UserSearch({ userName = "루카스", onClick }) {
+export default function UserSearch({
+  userName = "루카스",
+  profileImg,
+  onClick,
+}) {
   return (
     <Wrapper onClick={onClick}>
-      <StyledImage src="https://picsum.photos/200" />
+      <StyledImage src={profileImg} />
       <InnerWrapper>{userName}</InnerWrapper>
     </Wrapper>
   );
@@ -32,5 +36,6 @@ export default function UserSearch({ userName = "루카스", onClick }) {
 
 UserSearch.propTypes = {
   userName: PropTypes.string,
+  profileImg: PropTypes.string,
   onClick: PropTypes.func,
 };

--- a/src/components/UserSearch/UserSearch.js
+++ b/src/components/UserSearch/UserSearch.js
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import styled from "@emotion/styled";
 import Image from "../Image/Image";
+import DEFAULT_PROFILE_IMAGE_URL from "../../utils/constants";
 
 const Wrapper = styled.div`
   display: flex;
@@ -23,7 +24,7 @@ const StyledImage = styled(Image)`
 `;
 export default function UserSearch({
   userName = "루카스",
-  profileImg,
+  profileImg = DEFAULT_PROFILE_IMAGE_URL,
   onClick,
 }) {
   return (

--- a/src/pages/MainPage/MainPage.js
+++ b/src/pages/MainPage/MainPage.js
@@ -159,6 +159,7 @@ export default function MainPage() {
                 <StyledCard
                   width={250}
                   src={e.image}
+                  profileImg={e.author.image}
                   title={e.title}
                   content={e.content}
                   userName={e.author.fullName}

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -130,7 +130,7 @@ const Profile = () => {
       </Header>
       <Main>
         <Image
-          src="https://picsum.photos/200"
+          src={user && user.image}
           style={{
             width: "400px",
             height: "400px",
@@ -225,6 +225,7 @@ const Profile = () => {
                   likeCount={e.likes.length}
                   commentCount={e.comments.length}
                   src={e.image}
+                  profileImg={e.author.image}
                   date={e.createdAt.slice(0, 10)}
                   key={e._id}
                   onClick={() => {

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -14,6 +14,7 @@ import { useGetPostsByAuthorId } from "../../utils/apis/posts";
 import { useGlobalContext } from "../../store/GlobalProvider";
 import parseJsonStringToObject from "../../utils/parseJsonString";
 import { useGetUser } from "../../utils/apis/users";
+import DEFAULT_PROFILE_IMAGE_URL from "../../utils/constants";
 
 const Header = styled.header`
   position: sticky;
@@ -130,7 +131,7 @@ const Profile = () => {
       </Header>
       <Main>
         <Image
-          src={user && user.image}
+          src={(user && user.image) || DEFAULT_PROFILE_IMAGE_URL}
           style={{
             width: "400px",
             height: "400px",

--- a/src/pages/Search/SearchPage.js
+++ b/src/pages/Search/SearchPage.js
@@ -106,6 +106,7 @@ export default function SearchPage() {
               <UserSearch
                 userName={e.fullName}
                 key={e._id}
+                profileImg={e.image}
                 onClick={() =>
                   navigate("/profile", { state: { authorId: e._id } })
                 }
@@ -127,9 +128,9 @@ export default function SearchPage() {
                 date={e.createdAt.slice(0, 10)}
                 likeCount={e.likes.length}
                 src={e.image}
+                profileImg={e.author.image}
                 title={e.title}
                 key={e._id}
-                profileImg
                 userName
                 onClick={() => onClickPost(e._id)}
               />

--- a/src/pages/UpdateProfile/UpdateProfile.js
+++ b/src/pages/UpdateProfile/UpdateProfile.js
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 import { Save } from "react-feather";
 import UpperHeader from "../../components/Header/UpperHeader";
-// import Image from "../../components/Image/Image";
 import Input from "../../components/Input/Input";
 import Text from "../../components/Text/Text";
 import Button from "../../components/Button/Button";
@@ -14,6 +13,7 @@ import {
   updateUserInfo,
   updatePassword,
 } from "../../utils/apis/users";
+import DEFAULT_PROFILE_IMAGE_URL from "../../utils/constants";
 
 const Header = styled.header`
   position: sticky;
@@ -84,7 +84,8 @@ const UpdateProfile = () => {
   const jsonString = state.userInfo.user && state.userInfo.user.username;
   const defaultFullName =
     (state.userInfo.user && state.userInfo.user.fullName) || "";
-  const defaultImage = (state.userInfo && state.userInfo.user.image) || "";
+  const defaultImage =
+    (state.userInfo && state.userInfo.user.image) || DEFAULT_PROFILE_IMAGE_URL;
   const {
     height: defaultHeight,
     weight: defaultWeight,

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,4 @@
+const DEFAULT_PROFILE_IMAGE_URL =
+  "https://toppng.com/uploads/preview/instagram-default-profile-picture-11562973083brycehrmyv.png";
+
+export default DEFAULT_PROFILE_IMAGE_URL;


### PR DESCRIPTION
<!-- 제목 : Feature/#이슈번호-description -->

# 개요

렌더링시 프로필 이미지 적용하기

# 작업 내용

- 메인페이지, 검색페이지, 상세페이지, 프로필페이지, 댓글 프로필 이미지 적용
- 프로필 등록 안했을 경우 기본 프로필 이미지 적용

# 사진
<img width="1440" alt="스크린샷 2022-06-22 오전 11 52 03" src="https://user-images.githubusercontent.com/16220817/174933260-3bd62708-394d-46a7-ba4a-ad1e507a494a.png">
<img width="1440" alt="스크린샷 2022-06-22 오전 11 52 17" src="https://user-images.githubusercontent.com/16220817/174933276-0750bb14-4a62-43dd-a46c-e8bc77420b34.png">
<img width="1440" alt="스크린샷 2022-06-22 오전 11 52 41" src="https://user-images.githubusercontent.com/16220817/174933280-38993aa5-85b7-497e-839a-e2e1a14b9f98.png">

# 중점적으로 봐줬으면 하는 부분 (선택 사항)
